### PR TITLE
fix: release-drafter config typo

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-ame-template: 'v$RESOLVED_VERSION 🌈'
+name-template: 'v$RESOLVED_VERSION 🌈'
 
 tag-template: 'v$RESOLVED_VERSION'
 


### PR DESCRIPTION
# PR PagoNxt

## Description
After comparing the config file with other repo, I found that issue.

## Closes/fixes/resolves issue(s)?

## What was added/changed/fixed?

## Others [Optional]

## Checklist (after created PR)
- [ ] Added reviewers
- [ ] Added assignee(s)
- [ ] Added label(s)
- [ ] Added to project
- [ ] Added to milestone
- [ ] README.md has been updated after any changes to variables and outputs
