### PR TITLE
replace release-drafter workflow with reusable

### DIFF
--- a/workflow-templates/release-drafter.properties.json
+++ b/workflow-templates/release-drafter.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Releases Drafter",
-    "description": "Automate Drafts your next release notes. When Pull-Requests are merged into main brach. Version Release be resolved automatically based on labels of individual pull requests.\r\nAppend the following file 'https://github.com/pagonxt/.github/blob/master/.github/release-drafter.yml' into your '.github' folder. Official Project and Docs: https://github.com/release-drafter/release-drafter",
+    "description": "Automated drafts for your next release notes and Pull Requests autolabeling. When Pull-Requests are merged into main brach. Version Release be resolved automatically based on labels of individual pull requests.\r\nOfficial Project and Docs: https://github.com/release-drafter/release-drafter",
     "iconName": "drafter",
     "categories": null
 }

--- a/workflow-templates/release-drafter.yml
+++ b/workflow-templates/release-drafter.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, reopened, synchronize]
   push:
     branches:
-      - $default-branch
+      - main
+      - master
 
 jobs:
   release-drafter:

--- a/workflow-templates/release-drafter.yml
+++ b/workflow-templates/release-drafter.yml
@@ -5,27 +5,8 @@ on:
     types: [opened, reopened, synchronize]
   push:
     branches:
-      - main
-      - master
+      - $default-branch
 
 jobs:
-  Autolabeler_Pull_Requests:
-    if: github.event_name == 'pull_request'
-    runs-on: [ self-hosted, ubuntu-latest ]
-    steps:
-      - name: Pull Requests Autolabeler
-        uses: release-drafter/release-drafter@fe52e97d262833ae07d05efaf1a239df3f1b5cd4
-        with:
-          disable-releaser: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  Create_or_Update_Release_Draft:
-    if: github.event_name == 'push'
-    runs-on: [ self-hosted, ubuntu-latest ]
-    steps:
-      - name: Create/Update Release Drafter
-        uses: release-drafter/release-drafter@fe52e97d262833ae07d05efaf1a239df3f1b5cd4
-        with:
-          disable-autolabeler: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release-drafter:
+    uses: pagonxt/workflows/.github/workflows/release-drafter-v1.yml@main


### PR DESCRIPTION
# PR PagoNxt

## Description

Updates the release-drafter workflow template to use the reusable workflow.

## Closes/fixes/resolves issue(s)?

## What was added/changed/fixed?

## Others [Optional]

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [ ] Added to project
- [ ] Added to milestone
- [x] README.md has been updated after any changes to variables and outputs
